### PR TITLE
putting back config to see if it fixes missing items in sidekick, eve…

### DIFF
--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -1,0 +1,23 @@
+{
+    "project": "MAX 2024",
+    "plugins":[
+        {
+            "id": "asset-library",
+            "title": "My Assets",
+            "environments": ["preview","live", "edit"],
+            "url": "https://experience.adobe.com/solutions/CQ-assets-selectors/static-assets/resources/franklin/asset-selector.html?rail=false",
+            "isPalette": true,
+            "includePaths": [ "**.docx**" ],
+            "passConfig": true,
+            "paletteRect": "top: 50px; bottom: 10px; right: 10px; left: auto; width:400px; height: calc(100vh - 60px)",
+        },
+        {
+          "id": "generate-variations",
+          "title": "Generate Variations",
+          "url": "https://experience.adobe.com/aem/generate-variations",
+          "passConfig": true,
+          "environments": ["preview","live", "edit"],
+          "includePaths": ["**.docx**"]
+        }
+    ]
+}


### PR DESCRIPTION
putting back config to see if it fixes missing items in sidekick, even though we are using the config api

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--2024maxgenstudio--whatwork.aem.live/
- After: https://benge-working--2024maxgenstudio--whatwork.aem.live/
